### PR TITLE
🦄 feat: Use an init container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ target/
 
 ### VS Code ###
 .vscode/
+
+### Horizon Config
+core/opennms-overlay

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,16 +46,11 @@ services:
       - "8080:8080/tcp"
 
   horizon-init:
-    image: opennms/horizon:32.0.4
-    depends_on:
-      database:
-        condition: service_healthy
-      kafka:
-        condition: service_started
+    image: quay.io/labmonkeys/git:2.40.1.b2311
     env_file: opennms-stack.env
     volumes:
-      - ./core/opennms-overlay:/opt/opennms-overlay
-    command: ["-i"]
+      - ./core/opennms-overlay:/data/opennms-overlay
+    command: ["/init.sh"]
 
   horizon:
     image: opennms/horizon:32.0.4

--- a/opennms-stack.env
+++ b/opennms-stack.env
@@ -5,3 +5,4 @@ POSTGRES_PASSWORD=postgres
 OPENNMS_DBNAME=opennms
 OPENNMS_DBUSER=opennms
 OPENNMS_DBPASS=opennms
+GIT_REPO=opennms-forge/gitops-opennms-config


### PR DESCRIPTION
Use. a git init container that checks out the configuration from the gitops-opennms-config repository. The repository is defined in the GIT_REPO environment variable. The git init container can use the following environment variables:

* Required: GIT_REPO="opennms-forge/gitops-opennms-config"
* Optional with a default: GIT_HOST="${GIT_HOST:-github.com}"
* Optional with a default: GIT_HOST_SCHEME="${GIT_HOST_SCHEME:-https}"
* Optional: GIT_USER="<a-user-if-you-want-a-private-repo"
* Optional: GIT_PASS="<a-user-password-if-you-want-to-use-a-private-repo>"

The logic of the git init container behavior can be found in https://github.com/labmonkeys-space/app-container/blob/main/git/init.sh

Resolve: #1 
